### PR TITLE
make offscreen `gym-miniworld` work without updating nvidia drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
     - python3 -m flake8 . --count --show-source --statistics --select=E901,E999,F821,F822,F823
 
     # Test the simulator
-    - PYOPENGL_PLATFORM=egl python run_tests.py
+    - xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" ./run_tests.py
 
     # Test RL code quickly
-    - PYOPENGL_PLATFORM=egl cd pytorch-a2c-ppo-acktr && time python3 main.py --no-cuda --algo a2c --log-interval 1 --num-frames 200 --num-processes 1 --num-steps 80 --lr 0.00005 --env-name MiniWorld-Hallway-v0
+    - cd pytorch-a2c-ppo-acktr && xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" time python3 main.py --no-cuda --algo a2c --log-interval 1 --num-frames 200 --num-processes 1 --num-steps 80 --lr 0.00005 --env-name MiniWorld-Hallway-v0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3.5"
+    - "3.6"
 
 # Commands to install dependencies
 install:
@@ -15,7 +15,7 @@ script:
     - python3 -m flake8 . --count --show-source --statistics --select=E901,E999,F821,F822,F823
 
     # Test the simulator
-    - xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" ./run_tests.py
+    - PYOPENGL_PLATFORM=egl python run_tests.py
 
     # Test RL code quickly
-    - cd pytorch-a2c-ppo-acktr && xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" time python3 main.py --no-cuda --algo a2c --log-interval 1 --num-frames 200 --num-processes 1 --num-steps 80 --lr 0.00005 --env-name MiniWorld-Hallway-v0
+    - PYOPENGL_PLATFORM=egl cd pytorch-a2c-ppo-acktr && time python3 main.py --no-cuda --algo a2c --log-interval 1 --num-frames 200 --num-processes 1 --num-steps 80 --lr 0.00005 --env-name MiniWorld-Hallway-v0

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd gym-miniworld
 pip3 install -e .
 ```
 
-If you run into any problems, please take a look at the [troubleshooting guide](docs/troubleshooting.md), and if you're still stuck, please
+If you run into any problems, please take a look at the [troubleshooting guide](docs/troubleshooting.md), and if you' re still stuck, please
 [open an issue](https://github.com/maximecb/gym-miniworld/issues) on this
 repository to let us know something is wrong.
 
@@ -113,3 +113,9 @@ Then, to visualize the results of training, you can run the following command. N
 ```
 python3 enjoy.py --env-name MiniWorld-Hallway-v0 --load-dir trained_models/ppo
 ```
+
+### Offscreen Rendering
+You can run `gym-miniword` offscreen by setting the environment variable `PYOPENGL_PLATFORM` to `egl`.
+
+```
+PYOPENGL_PLATFORM=egl python3 --env-name MiniWorld-Hallway-v0 ...```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd gym-miniworld
 pip3 install -e .
 ```
 
-If you run into any problems, please take a look at the [troubleshooting guide](docs/troubleshooting.md), and if you' re still stuck, please
+If you run into any problems, please take a look at the [troubleshooting guide](docs/troubleshooting.md), and if you're still stuck, please
 [open an issue](https://github.com/maximecb/gym-miniworld/issues) on this
 repository to let us know something is wrong.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,6 @@ xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" ./run
 
 Depending on which system you are running this command, you may need to install xvfb and mesa packages.
 
-
 ## Running headless and training on AWS
 
 We recommend using the Ubuntu-based [Deep Learning AMI](https://aws.amazon.com/marketplace/pp/B077GCH38C) to provision your server which comes with all the deep learning libraries. To begin with, you will want to install xvfb and mesa. You may also need to uninstall the Nvidia display drivers in order for OpenGL/GLX to work properly:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,6 +26,7 @@ xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" ./run
 
 Depending on which system you are running this command, you may need to install xvfb and mesa packages.
 
+
 ## Running headless and training on AWS
 
 We recommend using the Ubuntu-based [Deep Learning AMI](https://aws.amazon.com/marketplace/pp/B077GCH38C) to provision your server which comes with all the deep learning libraries. To begin with, you will want to install xvfb and mesa. You may also need to uninstall the Nvidia display drivers in order for OpenGL/GLX to work properly:
@@ -47,6 +48,11 @@ Once this is done, you should be able to run training code through `xvfb-run`, f
 ```
 cd pytorch-a2c-ppo-acktr
 xvfb-run -a -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" python3 main.py --algo ppo --num-processes 16 --num-steps 80 --lr 0.00005 --env-name MiniWorld-Hallway-v0
+```
+
+alternatively you can set the environment variable `PYOPENGL_PLATFORM` to `egl` (requires `pyglet==1.5.11`) to force `gym-miniworld` to render offscreen:
+```
+PYOPENGL_PLATFORM=egl python3 main.py --algo ppo --num-processes 16 --num-steps 80 --lr 0.00005 --env-name MiniWorld-Hallway-v0
 ```
 
 ## Poor performance, low frame rate

--- a/gym_miniworld/opengl.py
+++ b/gym_miniworld/opengl.py
@@ -2,6 +2,12 @@ import math
 import os
 import numpy as np
 import pyglet
+
+# Solution to https://github.com/maximecb/gym-miniworld/issues/24
+# until pyglet support egl officially
+if os.environ.get('PYOPENGL_PLATFORM', None) == 'egl':
+    pyglet.options['headless'] = True
+
 from pyglet.gl import *
 from ctypes import byref, POINTER
 from .utils import *

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires=[
         'gym>=0.9.0',
         'numpy>=1.10.0',
-        'pyglet',
+        'pyglet>=1.5.11',
     ],
     # Include textures and meshes in the package
     include_package_data=True


### PR DESCRIPTION
I've tested on an nvidia headless remote node and updated travis tests too (they're passing https://travis-ci.com/github/ptigas/gym-miniworld/builds/222853711).

The idea is to switch to headless once you set `PYOPENGL_PLATFORM=egl` (might not be the best idea; let me know what you think)