### PR TITLE
wrap write to ObjMesh.cache in a Lock

### DIFF
--- a/gym_miniworld/objmesh.py
+++ b/gym_miniworld/objmesh.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import math
 import numpy as np
@@ -26,7 +27,8 @@ class ObjMesh:
             return self.cache[file_path]
 
         mesh = ObjMesh(file_path)
-        self.cache[file_path] = mesh
+        with multiprocessing.Lock():
+            self.cache[file_path] = mesh
 
         return mesh
 


### PR DESCRIPTION
I am suggesting adding a lock here because otherwise there is a race condition on `ObjMesh.cache` when using gym-miniworld environments in a parallel environments setting, e.g. [`SubprocVecEnv`](https://stable-baselines.readthedocs.io/en/master/guide/vec_envs.html#subprocvecenv).